### PR TITLE
Update index.mjs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,3 +1,6 @@
+import { createRequire } from 'module';  //added for new version of node
+const require = createRequire(import.meta.url);
+
 require('dotenv').config();
 
 import NameCheap from '@rqt/namecheap';


### PR DESCRIPTION
The new Ubuntu 20.04 LTS and newest install of node required this, REQUIRE is no longer included in the package: https://stackoverflow.com/a/64818509/13915403 for more information